### PR TITLE
Remove marker if AllAlivePlayersList no longer contains player

### DIFF
--- a/DynamicMarkers/OtherPlayersMarkerProvider.cs
+++ b/DynamicMarkers/OtherPlayersMarkerProvider.cs
@@ -202,7 +202,7 @@ namespace DynamicMaps.DynamicMarkers
             foreach (var player in _playerMarkers.Keys.ToList())
             {
                 var marker = _playerMarkers[player];
-                if (player.HasCorpse())
+                if (player.HasCorpse() || !Singleton<GameWorld>.Instance.AllAlivePlayersList.Contains(player))
                 {
                     TryRemoveMarker(player);
                 }


### PR DESCRIPTION
This fixes a bug where mods like SWAG + Donuts despawn AI but the marker stays on the map, tested with a quick testing function and seems to now have the proper behavior.