### PR TITLE
Ignore dedicated server player map marker

### DIFF
--- a/DynamicMarkers/OtherPlayersMarkerProvider.cs
+++ b/DynamicMarkers/OtherPlayersMarkerProvider.cs
@@ -217,7 +217,7 @@ namespace DynamicMaps.DynamicMarkers
                 return;
             }
 
-            if (_lastMapView == null || player.IsBTRShooter() || _playerMarkers.ContainsKey(player))
+            if (_lastMapView == null || player.IsBTRShooter() || _playerMarkers.ContainsKey(player) || player.IsDedicatedServer())
             {
                 return;
             }

--- a/DynamicMarkers/PlayerMarkerProvider.cs
+++ b/DynamicMarkers/PlayerMarkerProvider.cs
@@ -48,7 +48,7 @@ namespace DynamicMaps.DynamicMarkers
             }
 
             var player = GameUtils.GetMainPlayer();
-            if (player == null)
+            if (player == null || player.IsDedicatedServer())
             {
                 return;
             }

--- a/Utils/GameUtils.cs
+++ b/Utils/GameUtils.cs
@@ -114,6 +114,12 @@ namespace DynamicMaps.Utils
             return player.Profile.Side == EPlayerSide.Bear || player.Profile.Side == EPlayerSide.Usec;
         }
 
+        public static bool IsDedicatedServer(this IPlayer player)
+        {
+            string pattern = @"^dedicated_[a-fA-F0-9]{24}$";
+            return Regex.IsMatch(player.Profile.GetCorrectedNickname(), pattern);
+        }
+
         public static bool DidMainPlayerKill(this IPlayer player)
         {
             var aggressor = _playerLastAggressorField.GetValue(player) as IPlayer;


### PR DESCRIPTION
- Added isDedicatedServer() method to validate if the player name matches the dedicated server player name format.
- Updated areas adding map markers to ignore players who are flagged as dedicated servers.